### PR TITLE
Fix URL prefix matching.

### DIFF
--- a/captcha.go
+++ b/captcha.go
@@ -203,9 +203,9 @@ func Captchaer(options ...Options) macaron.Handler {
 	return func(ctx *macaron.Context, cache cache.Cache) {
 		cpt.store = cache
 
-		if strings.HasPrefix(ctx.Req.RequestURI, cpt.URLPrefix) {
+		if strings.HasPrefix(ctx.Req.URL.Path, cpt.URLPrefix) {
 			var chars string
-			id := path.Base(ctx.Req.RequestURI)
+			id := path.Base(ctx.Req.URL.Path)
 			if i := strings.Index(id, "."); i > -1 {
 				id = id[:i]
 			}


### PR DESCRIPTION
net/http/fcgi does not set RequestURI in request. So, captcha does not work with FCGI.

By the way, Macaron itself uses Request.URL.Path to match paths for routing, not Request.RequestURI.